### PR TITLE
fixed bug Permission denied on Cloud KMS key. Please ensure that your…

### DIFF
--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -122,11 +122,12 @@ resource "google_kms_crypto_key" "tf_key" {
 
 resource "google_kms_crypto_key_iam_binding" "cloudbuild_crypto_key_decrypter" {
   crypto_key_id = google_kms_crypto_key.tf_key.id
-  role          = "roles/cloudkms.cryptoKeyDecrypter"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   members = [
     "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com",
-    "serviceAccount:${var.terraform_sa_email}"
+    "serviceAccount:${var.terraform_sa_email}",
+    "serviceAccount:service-${module.cloudbuild_project.project_number}@gs-project-accounts.iam.gserviceaccount.com"
   ]
 }
 

--- a/modules/terraform-google-bootstrap/main.tf
+++ b/modules/terraform-google-bootstrap/main.tf
@@ -119,17 +119,17 @@ resource "google_storage_bucket" "org_terraform_state" {
   versioning {
     enabled = true
   }
-   encryption {
-      default_kms_key_name = module.kms.keys["${var.project_prefix}-key"]
-    }
+  encryption {
+    default_kms_key_name = module.kms.keys["${var.project_prefix}-key"]
+  }
 }
 
 //Creating folder to store UI evidence
 
 resource "google_storage_bucket_object" "ui_evidence" {
-  name          = "ui-evidence/"
-  content       = "To store evidences collected form UI."
-  bucket        = google_storage_bucket.org_terraform_state.name
+  name    = "ui-evidence/"
+  content = "To store evidences collected form UI."
+  bucket  = google_storage_bucket.org_terraform_state.name
 }
 
 /***********************************************
@@ -137,6 +137,12 @@ resource "google_storage_bucket_object" "ui_evidence" {
   remove default org wide permissions
   granting billing account and project creation.
  ***********************************************/
+resource "google_project_iam_binding" "gs_encrypt_decrypt" {
+  members = [
+  "serviceAccount: service-${module.seed_project.project_number}@gs-project-accounts.iam.gserviceaccount.com"]
+  project = module.seed_project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+}
 
 resource "google_organization_iam_binding" "billing_creator" {
   org_id = var.org_id


### PR DESCRIPTION
After enabling encryption on the bucket for compliance, Getting the below error while deploying the `0-bootstrap` stage.

```│ Error: googleapi: Error 403: Permission denied on Cloud KMS key. Please ensure that your Cloud Storage service account has been authorized to use this key., forbidden
│ 
│   with module.cloudbuild_bootstrap.google_storage_bucket.cloudbuild_artifacts,
│   on ../modules/cloudbuild/main.tf line 77, in resource "google_storage_bucket" "cloudbuild_artifacts":
│   77: resource "google_storage_bucket" "cloudbuild_artifacts" {
│ 
╵
```

Solution: GCP has a bucket service account which needs to have `roles/cloudkms.cryptoKeyEncrypterDecrypter` assigned. 