### PR TITLE
fixed module issue in terraform-google-github-actions-runners

### DIFF
--- a/modules/terraform-google-github-actions-runners/modules/gh-runner-mig-vm/main.tf
+++ b/modules/terraform-google-github-actions-runners/modules/gh-runner-mig-vm/main.tf
@@ -147,6 +147,8 @@ module "mig_template" {
   source_image         = var.source_image
   shielded_instance_config = {
     enable_secure_boot = true
+    enable_vtpm        = true
+    enable_integrity_monitoring = true
   }
   metadata = merge({
     "secret-id" = google_secret_manager_secret_version.gh-secret-version.name


### PR DESCRIPTION
### Which stage is this PR for? Tick only 1 option.
- [ ] `0-bootstrap`
- [ ] `1-org`
- [ ] `2-env`
- [ ] `3-networks`
- [ ] `4-projects`
- [ ] `5-app-infra`
- [x] `modules`
- [ ] `Others`

### Which environment is this being deployed for? Tick as applicable based on above question.
- [ ] `shared`
- [ ] `development`
- [ ] `staging`
- [ ] `production`
- [ ] `NA`

### Are the previous stages/environments deployed? Tick as applicable based on above questions.
- [ ] `Yes`
- [ ] `No`
- [ ] `NA`

### Have you checked for any typos and/or spelling mistakes?
- [ ] `Yes`
- [ ] `No`

### Is this linked to any existing issues?
- [ ] `Yes`
- [ ] `No`



**Issue detail :** 
getting error while running wrapper.sh  scrpit :



`
│ Error: Invalid value for module argument
│ 
│  on ../modules/terraform-google-github-actions-runners/modules/gh-runner-mig-vm/main.tf line 148, in module "mig_template":
│ 148:  shielded_instance_config = {
│ 149:   enable_secure_boot = true
│ 150:  }
│ 
│ The given value is not suitable for child module variable "shielded_instance_config" defined at ../modules/instance_template/variables.tf:206,1-36:
│ attributes "enable_integrity_monitoring" and "enable_vtpm" are required.
╵
`